### PR TITLE
Improve performance, remove string based checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,28 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cc"
@@ -24,6 +42,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +75,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -56,12 +104,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "md5_cracker"
 version = "0.1.0"
 dependencies = [
+ "md-5",
+ "once_cell",
  "openssl",
  "rand",
+ "regex",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "once_cell"
@@ -168,6 +235,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +273,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -189,6 +291,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+md-5 = "0.10.6"
+once_cell = "1.18.0"
 openssl = "0.10.59"
 rand = "0.8.5"
+regex = "1.10.2"
 
 [features]
 perf = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 openssl = "0.10.59"
 rand = "0.8.5"
+
+[features]
+perf = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,21 +2,21 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 
-use std::borrow::Cow;
-
+use once_cell::sync::Lazy;
 use openssl::{md::Md, md_ctx::MdCtx};
 use rand::{distributions, thread_rng, Rng};
+use regex::bytes::Regex;
+
+type Digest = [u8; 32];
+
+/// Regex to detect an escape, followed by an OR pattern, followed by another opening single quote then a digit
+/// This is significantly faster than the previous string search method.
+// TODO: Find how stop this from being SYNC, as taking the lock wastes a lot of time.
+static INJECTION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"'(\|\||or)'\d").unwrap());
 
 #[inline]
-fn validate(str_digest: &str) -> bool {
-    if let Some(sub) = str_digest.find("'||'").or_else(|| str_digest.find("'or'")) {
-        if let Some(eval) = str_digest[sub..].chars().nth(4) {
-            if eval > '0' && eval < '9' {
-                return true;
-            }
-        }
-    }
-    false
+fn byte_validate(digest: &Digest) -> bool {
+    INJECTION_REGEX.is_match(digest)
 }
 
 // 87153179503375488964249572016766023268706569805029887102402011499288342510775092757977654940386142689199562616975803271832089582121260280598138107679172885818920928633840231384484533108096150415512236913966
@@ -26,17 +26,16 @@ fn main() {
 }
 
 fn crack() {
+    // Create all in memory objects here to reduce re-allocation.
     let mut i = 0;
     let mut buf = String::with_capacity(400);
-    let mut digest = [0; 32];
+    let mut digest: Digest = [0; 32];
     // Ascii codes for digits.
     let uniform_ascii_digits = distributions::Uniform::from(48..=57);
+    let mut ctx = MdCtx::new().unwrap();
     // Distribution for selecting random
-    let uniform_take_range = distributions::Uniform::from(1..=4);
     loop {
-        if i % 10000 == 0 {
-            #[cfg(debug_assertions)]
-            println!("{buf}");
+        if i % 1_000_000 == 0 {
             println!("i = {i}");
         }
 
@@ -52,12 +51,6 @@ fn crack() {
         i += 1;
 
         // Push new string to buf
-        // thread_rng()
-        //     .sample_iter(uniform_ascii_digits)
-        //     .take(thread_rng().sample(uniform_take_range))
-        //     .filter_map(char::from_u32)
-        //     .for_each(|ch| buf.push(ch));
-
         unsafe {
             buf.push(char::from_u32_unchecked(
                 thread_rng().sample(uniform_ascii_digits),
@@ -65,12 +58,14 @@ fn crack() {
         }
 
         // Calculate md5 hash
-        let str_digest = openssl_str_digest(&buf, &mut digest);
+        // let str_digest = openssl_str_digest(&buf, &mut digest);
+        openssl_digest(&mut ctx, &buf, &mut digest);
 
         // Check if we can create the OR statement from it.
-        if validate(&str_digest) {
+        if byte_validate(&digest) {
             println!("Found! i = {i}");
             println!("Content = {buf}");
+            let str_digest = String::from_utf8_lossy(&digest);
             println!("Raw md5 Hash = {str_digest}");
             return;
         }
@@ -78,13 +73,10 @@ fn crack() {
 }
 
 #[inline]
-fn openssl_str_digest<'a>(buf: &str, digest: &'a mut [u8; 32]) -> Cow<'a, str> {
-    let mut ctx = MdCtx::new().unwrap();
+fn openssl_digest(ctx: &mut MdCtx, buf: &str, digest: &mut [u8; 32]) {
     ctx.digest_init(Md::md5()).unwrap();
     ctx.digest_update(buf.as_bytes()).unwrap();
     ctx.digest_final(digest).unwrap();
-
-    String::from_utf8_lossy(digest)
 }
 
 #[test]
@@ -93,12 +85,10 @@ fn test_validation() {
 
     let mut digest = [0; 32];
     let mut ctx = MdCtx::new().unwrap();
-    ctx.digest_init(Md::md5()).unwrap();
-    ctx.digest_update(buf.as_bytes()).unwrap();
-    ctx.digest_final(&mut digest).unwrap();
 
-    let str_digest = openssl_str_digest(buf, &mut digest);
+    openssl_digest(&mut ctx, buf, &mut digest);
 
+    let str_digest = String::from_utf8_lossy(&digest);
     println!("{str_digest}");
-    assert!(validate(&str_digest));
+    assert!(byte_validate(&digest));
 }


### PR DESCRIPTION
## Overview 
Reduces time to compute per 10_000_000 hashes by 2 (local testing). 

## Changes
- Changes the validation function to use a byte regex. Perf analysis showed that a major part of computation was spent converting the bytes into a string and then searching the string. This both reduces the time to search the output, and removes the need to convert to a String first. 
- Regex has been put in a sync once cell. 
- Reuse the md5 context between openssl calls. 
